### PR TITLE
SAKAI-2737 DDO is not saving records

### DIFF
--- a/pack/src/webapp/WEB-INF/components.xml
+++ b/pack/src/webapp/WEB-INF/components.xml
@@ -36,13 +36,21 @@
     </bean>
     
     <!-- DAO. This uses the DataSource that has already been setup by Sakai  -->
+
+	<!-- Need to set up auto commit for default datasource -->
+	<bean id="org.sakaiproject.ddo.dao.AutoCommitDataSource" parent="javax.sql.DataSource">
+		<property name="autoCommit">
+			<value>true</value>
+		</property>
+	</bean>
+
 	<bean id="org.sakaiproject.ddo.dao.ProjectDao"
 		class="org.sakaiproject.ddo.dao.impl.ProjectDaoImpl"
 		init-method="init">
 		<property name="jdbcTemplate">
 			<bean class="org.springframework.jdbc.core.JdbcTemplate">
 				<constructor-arg type="javax.sql.DataSource">
-					<ref bean="javax.sql.DataSource" />
+					<ref bean="org.sakaiproject.ddo.dao.AutoCommitDataSource" />
 				</constructor-arg>
 			</bean>
 		</property>	


### PR DESCRIPTION
DDO was not saving records in Sakai 11. The default datasource had changed
and no longer auto committed changes. This simply creates a new data source
specifically for ddo based on the default sakai datasource except that it
turns on autocommit.